### PR TITLE
Add gh link to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,5 @@ Suggests:
 Depends: 
     R (>= 2.10)
 VignetteBuilder: knitr
-URL: https://dreamrs.github.io/flexpivot/
+URL: https://dreamrs.github.io/flexpivot/, https://github.com/dreamRs/flexpivot
+BugReports: https://github.com/dreamRs/flexpivot/issues


### PR DESCRIPTION
to improve linking between rendered website and repo and improve discoverability https://blog.r-hub.io/2019/12/10/urls/